### PR TITLE
Compile issues on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You don't need to be proficient with all of these technologies to help! Check ou
 
 ## Making a contribution
 
-First, set up the project:
+1) Set up the project:
 ```bash
 # Clone the repository
 git clone https://github.com/YourUsername/NumDot
@@ -38,11 +38,17 @@ cd ..
 scons platform=macos
 ```
 
-Make a branch for your changes:
+**For Windows users:** It is recommended to use [MinGW](https://www.mingw-w64.org/) to compile the project as the build process currently invokes gcc-specific compiler flags that will **not** be recognized by [MSVC](https://visualstudio.microsoft.com/vs/features/cplusplus/). In this case, MinGW must be added to PATH and specified to scons like so:
+
+```bash
+scons platform=windows use-mingw=yes
+```
+
+2) Make a branch for your changes:
 ```bash
 git checkout -b my-new-feature
 ```
-Make your changes using a code editor (I use [VSCode](https://code.visualstudio.com)).Test your changes in the demo project. Generate empty documentation for new code:
+Make your changes using a code editor (I use [VSCode](https://code.visualstudio.com)). Test your changes in the demo project. Generate empty documentation for new code:
 
 ```bash
 cd demo && godot --doctool ../ --gdextension-docs
@@ -64,7 +70,7 @@ git commit -m "My change message."
 git push
 ```
 
-Finally, [make a Pull Request (PR)](https://github.com/Ivorforce/NumDot/compare). We will check your changes, make suggestions, and finally integrate your code into the project. Try to make sure you don't include any accidental changes, like editing the test file.
+3) Finally, [make a Pull Request (PR)](https://github.com/Ivorforce/NumDot/compare). We will check your changes, make suggestions, and finally integrate your code into the project. Try to make sure you don't include any accidental changes, like editing the test file.
 
 ## Any Problems?
 

--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Operations with tensors are also very easy to write and read, once you're famili
 NumDot is inspired by the python tensor math library, [NumPy](https://numpy.org), and thus shares many semantics with it. If you are unfamiliar with tensor operations in general, we recommend taking a numpy tutorial or two first. That being said, here are some direct comparison examples:
 
 | NumPy                             | NumDot                                                                                                                           |
-|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `x[a, b, c]`                      | `x.get(a, b, c)` ([syntax discussion](https://github.com/Ivorforce/NumDot/issues/6))                                             |
 | `x[...]` can return single values | `x.get(...)` always returns a tensor, use `x.get_float(...)` and `x.get_int(...)` to get values.                                 |
 | `x[a, b, c] = d`                  | `x.set(d, a, b, c)`                                                                                                              |
@@ -29,7 +29,7 @@ NumDot is inspired by the python tensor math library, [NumPy](https://numpy.org)
 | `np.sin(a)`                       | `nd.sin(a)`                                                                                                                      |
 | `np.mean(a, [1, -1])`             | `nd.mean(a, [1, -1])`                                                                                                            |
 | `np.reshape(a, (50, -1))`         | `nd.reshape(a, [50, -1])`                                                                                                        |
-| `np.transpose(a, (2, 0, 1))`      | `nd.transpose(a, [2, 0, 1])`                                                                                                       |
+| `np.transpose(a, (2, 0, 1))`      | `nd.transpose(a, [2, 0, 1])`                                                                                                     |
 
 Keep in mind these semantics are yet subject to change.
 
@@ -65,7 +65,9 @@ cd ..
 
 # Exceptions have to be explicitly enabled here
 scons platform=macos
-# You may have to build twice, see https://github.com/Ivorforce/NumDot/issues/23
+
+# On windows, use MinGW for compiling like so
+# scons platform=windows use-mingw=yes
 ```
 
 ### What Now?

--- a/src/vatensor/varray.h
+++ b/src/vatensor/varray.h
@@ -55,7 +55,7 @@ namespace va {
     using GivenAxes = std::vector<std::ptrdiff_t>;
 
     using Axes = std::variant<
-        nullptr_t,
+        std::nullptr_t,
         GivenAxes
     >;
 
@@ -64,7 +64,7 @@ namespace va {
 
     // P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A()
     template <typename T>
-    using compute_case = xt::xarray_adaptor<xt::xbuffer_adaptor<T*>,xt::layout_type::dynamic>;
+    using compute_case = xt::xarray_adaptor<xt::xbuffer_adaptor<T*>, xt::layout_type::dynamic>;
 
     using ComputeVariant = std::variant<
         compute_case<bool>,
@@ -110,7 +110,7 @@ namespace va {
         [[nodiscard]] size_t dimension() const;
 
         // TODO Can probably change these to subscript syntax
-        [[nodiscard]] VArray slice(const xt::xstrided_slice_vector &slices) const;
+        [[nodiscard]] VArray slice(const xt::xstrided_slice_vector& slices) const;
         void fill(VConstant value) const;
         void set_with_array(const VArray& value) const;
 


### PR DESCRIPTION
Changed a stray `nullptr_t` to be called through the `std` namespace and added some instructions to use MinGW to compile on Windows.