### PR TITLE
Kuramoto model demo

### DIFF
--- a/demo/demos/kuramoto_model/firefly.tres
+++ b/demo/demos/kuramoto_model/firefly.tres
@@ -1,0 +1,13 @@
+[gd_resource type="GradientTexture2D" load_steps=2 format=3 uid="uid://bt0oq50dfy0yq"]
+
+[sub_resource type="Gradient" id="Gradient_88cm8"]
+interpolation_mode = 1
+colors = PackedColorArray(1, 1, 0.227451, 1, 0, 0, 0, 0)
+
+[resource]
+gradient = SubResource("Gradient_88cm8")
+width = 3
+height = 3
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 1)

--- a/demo/demos/kuramoto_model/gd_solver.gd
+++ b/demo/demos/kuramoto_model/gd_solver.gd
@@ -1,13 +1,83 @@
 extends KuramotoSolver
 
-func initialize() -> void:
-	pass
+var omega: Array # natural frequencies
+var phase: Array # oscillator phases
 
-func simulation_step() -> void:
-	pass
+# pre-allocations
+var phase_coherence: float
+var avg_phase: float
+var phase_sin: Array
+var phase_cos: Array
+var phase_sin_sum: float
+var phase_cos_sum: float
+
+# rk4
+var kf: Array
+var k1: Array
+var k2: Array
+var k3: Array
+var k4: Array
+
+func initialize() -> void:
+	integrator = [Callable(euler_step), Callable(rk4_step)]
+	
+	phase.resize(params.N)
+	for i in phase.size(): phase[i] = randf_range(0, 2*PI)
+		
+	omega.resize(params.N)
+	for i in omega.size(): omega[i] = randfn(params.frequency_mean, params.frequency_sigma)
+
+	phase_sin.resize(params.N)
+	phase_cos.resize(params.N)
+	
+	kf.resize(params.N)
+	k1.resize(params.N)
+	k2.resize(params.N)
+	k3.resize(params.N)
+	k4.resize(params.N)
 	
 func on_draw() -> void:
-	pass
+	for i in params.N:
+		params.draw_circle(params.positions[i], params.entity_size, Color(params.entity_color, sin(phase[i])/2 + 0.5))
 
+func simulation_step() -> void:
+	var dt_substep: float = params.dt / params.sub_steps
+	for i in params.sub_steps: integrator[params.integrator_idx].call(dt_substep)
+
+func compute_derivative(df: Array, phase: Array):
+	phase_sin_sum = 0.
+	phase_cos_sum = 0.
+	
+	for i in phase.size(): 
+		phase_sin[i] = sin(phase[i])
+		phase_cos[i] = cos(phase[i])
+		phase_sin_sum += phase_sin[i]
+		phase_cos_sum += phase_cos[i]
+		
+	phase_coherence = sqrt(phase_sin_sum**2 + phase_cos_sum**2) / params.N
+	avg_phase = atan2(phase_sin_sum, phase_cos_sum)
+	
+	for i in phase.size():
+		df[i] = omega[i] + params.coupling * phase_coherence * sin(phase[i] - avg_phase)
+	
 func generate_frequencies() -> void:
-	pass
+	omega.resize(params.N)
+	for i in omega.size(): randfn(params.frequency_mean, params.frequency_sigma)
+
+func euler_step(dt: float) -> void:
+	compute_derivative(k1, phase)
+	for i in phase.size(): phase[i] += k1[i] * dt
+
+func rk4_step(dt: float) -> void:
+	compute_derivative(k1, phase)
+	
+	for i in phase.size(): kf[i] = phase[i] + k1[i] * dt/2
+	compute_derivative(k2, kf)
+	
+	for i in phase.size(): kf[i] = phase[i] + k2[i] * dt/2
+	compute_derivative(k3, kf)
+
+	for i in phase.size(): kf[i] = phase[i] + k3[i] * dt
+	compute_derivative(k4, kf)
+	
+	for i in phase.size(): phase[i] += dt/6 * (k1[i] + 2 * k2[i] + 2 * k3[i] + k4[i])

--- a/demo/demos/kuramoto_model/gd_solver.gd
+++ b/demo/demos/kuramoto_model/gd_solver.gd
@@ -1,0 +1,13 @@
+extends KuramotoSolver
+
+func initialize() -> void:
+	pass
+
+func simulation_step() -> void:
+	pass
+	
+func on_draw() -> void:
+	pass
+
+func generate_frequencies() -> void:
+	pass

--- a/demo/demos/kuramoto_model/gd_solver.gd
+++ b/demo/demos/kuramoto_model/gd_solver.gd
@@ -37,8 +37,7 @@ func initialize() -> void:
 	k4.resize(params.N)
 	
 func on_draw() -> void:
-	for i in params.N:
-		params.draw_circle(params.positions[i], params.entity_size, Color(params.entity_color, sin(phase[i])/2 + 0.5))
+	params.set_alphas(phase)
 
 func simulation_step() -> void:
 	var dt_substep: float = params.dt / params.sub_steps
@@ -58,7 +57,7 @@ func compute_derivative(df: Array, phase: Array):
 	avg_phase = atan2(phase_sin_sum, phase_cos_sum)
 	
 	for i in phase.size():
-		df[i] = omega[i] + params.coupling * phase_coherence * sin(phase[i] - avg_phase)
+		df[i] = omega[i] - params.coupling * phase_coherence * sin(phase[i] - avg_phase)
 	
 func generate_frequencies() -> void:
 	omega.resize(params.N)

--- a/demo/demos/kuramoto_model/kuramoto_model.gd
+++ b/demo/demos/kuramoto_model/kuramoto_model.gd
@@ -1,0 +1,74 @@
+extends Node2D
+
+@export_category("Simulation parameters")
+@export var N: int = 1000
+@export var coupling: float = 6
+@export var frequency_sigma:  float = 2
+@export var frequency_mean: float = 0.
+
+@export var dt: float = 1./60 # 60 fps
+@export var sub_steps: int = 1
+@export var solver: KuramotoSolver
+@export var integrator_idx: int = 0
+
+@export_category("Visual parameters")
+@export var entity_color: Color = Color.RED
+@export var entity_size: float = 2.
+
+# positions
+var positions := []
+var frame_time: float = 1./60
+
+func _ready() -> void:	
+	generate_positions()
+	solver.initialize()
+
+func _process(delta: float) -> void:
+	%FPSLabel.text = "FPS: " + str(Engine.get_frames_per_second())
+
+	frame_time = Time.get_ticks_usec()
+	solver.simulation_step()
+	frame_time = Time.get_ticks_usec() - frame_time
+	
+	%FrameTimeLabel.text = "Delta (ms): " + str(snappedf(frame_time/1000, 1e-3))	
+	queue_redraw()
+
+func _draw() -> void:
+	solver.on_draw()
+
+func generate_positions():
+	positions.resize(N)
+	for i in N: 
+		positions[i] = Vector2(randf_range(0, get_viewport().size.x), randf_range(0, get_viewport().size.y))
+
+func _on_point_slider_drag_ended(value_changed: bool) -> void:
+	%PointLabel.text = "Fireflies: " + str(%PointSlider.value)
+	N = %PointSlider.value
+	generate_positions()
+	solver.initialize()
+
+func _on_coupling_slider_drag_ended(value_changed: bool) -> void:
+	%CouplingLabel.text = "Coupling: " + str(%CouplingSlider.value)
+	coupling = %CouplingSlider.value
+
+func _on_mean_slider_drag_ended(value_changed: bool) -> void:
+	%MeanLabel.text = "Frequency mean: " + str(%MeanSlider.value)
+	solver.generate_frequencies()
+
+func _on_std_slider_drag_ended(value_changed: bool) -> void:
+	%StdLabel.text = "Frequency std: " + str(%StdSlider.value)
+	solver.generate_frequencies()
+
+func _on_restart_button_pressed() -> void:
+	solver.initialize()
+
+func _on_substep_slider_drag_ended(value_changed: bool) -> void:
+	%SubstepLabel.text = "Sub-steps: " + str(%SubstepSlider.value)
+	sub_steps = %SubstepSlider.value
+
+func _on_solver_option_item_selected(index: int) -> void:
+	solver = $Solvers.get_child(index)
+	solver.initialize()
+
+func _on_integrator_option_item_selected(index: int) -> void:
+	integrator_idx = index

--- a/demo/demos/kuramoto_model/kuramoto_model.tscn
+++ b/demo/demos/kuramoto_model/kuramoto_model.tscn
@@ -1,0 +1,179 @@
+[gd_scene load_steps=4 format=3 uid="uid://b0s40i0gcfwtk"]
+
+[ext_resource type="Script" path="res://demos/kuramoto_model/kuramoto_model.gd" id="1_4fesd"]
+[ext_resource type="Script" path="res://demos/kuramoto_model/gd_solver.gd" id="2_8q8fw"]
+[ext_resource type="Script" path="res://demos/kuramoto_model/nd_solver.gd" id="3_upt5u"]
+
+[node name="KuramotoModel" type="Node2D" node_paths=PackedStringArray("solver")]
+script = ExtResource("1_4fesd")
+N = 100
+coupling = 3.0
+solver = NodePath("Solvers/NDSolver")
+
+[node name="Solvers" type="Node" parent="."]
+
+[node name="GDSolver" type="Node" parent="Solvers" node_paths=PackedStringArray("params")]
+script = ExtResource("2_8q8fw")
+params = NodePath("../..")
+
+[node name="NDSolver" type="Node" parent="Solvers" node_paths=PackedStringArray("params")]
+script = ExtResource("3_upt5u")
+params = NodePath("../..")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+show_behind_parent = true
+custom_minimum_size = Vector2(1152, 648)
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_right = 1152.0
+offset_bottom = 648.0
+grow_horizontal = 2
+color = Color(0.0437092, 0.0736913, 0.101474, 1)
+
+[node name="Labels" type="VBoxContainer" parent="."]
+offset_left = 23.0
+offset_top = 18.0
+offset_right = 223.0
+offset_bottom = 118.0
+metadata/_edit_group_ = true
+
+[node name="FPSLabel" type="Label" parent="Labels"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "FPS: 60"
+
+[node name="FrameTimeLabel" type="Label" parent="Labels"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Frame time: 1"
+
+[node name="SliderOptions" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(250, 0)
+offset_left = 22.0
+offset_top = 361.0
+offset_right = 305.0
+offset_bottom = 621.0
+metadata/_edit_group_ = true
+
+[node name="PointLabel" type="Label" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Fireflies: 100
+"
+
+[node name="PointSlider" type="HSlider" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 10.0
+max_value = 10000.0
+step = 100.0
+value = 110.0
+
+[node name="CouplingLabel" type="Label" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Coupling: 1.0"
+
+[node name="CouplingSlider" type="HSlider" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+max_value = 10.0
+step = 0.05
+value = 1.0
+
+[node name="MeanLabel" type="Label" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Frequency mean: 0."
+
+[node name="MeanSlider" type="HSlider" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+max_value = 6.28
+step = 0.1
+
+[node name="StdLabel" type="Label" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Frequency std: 2."
+
+[node name="StdSlider" type="HSlider" parent="SliderOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+max_value = 5.0
+step = 0.1
+value = 2.0
+
+[node name="Options" type="VBoxContainer" parent="."]
+offset_left = 862.0
+offset_top = 16.0
+offset_right = 1140.0
+offset_bottom = 120.0
+metadata/_edit_group_ = true
+
+[node name="SolverOption" type="OptionButton" parent="Options"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+selected = 0
+item_count = 3
+popup/item_0/text = "GDScript"
+popup/item_1/text = "NumDot"
+popup/item_1/id = 1
+popup/item_2/text = "NumDot In-place"
+popup/item_2/id = 2
+
+[node name="IntegratorOption" type="OptionButton" parent="Options"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+selected = 0
+item_count = 2
+popup/item_0/text = "Euler scheme"
+popup/item_1/text = "RK4 scheme"
+popup/item_1/id = 1
+
+[node name="SolverOptions" type="VBoxContainer" parent="."]
+custom_minimum_size = Vector2(200, 0)
+offset_left = 928.0
+offset_top = 565.0
+offset_right = 1128.0
+offset_bottom = 627.0
+metadata/_edit_group_ = true
+
+[node name="SubstepLabel" type="Label" parent="SolverOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Sub-steps: 1"
+
+[node name="SubstepSlider" type="HSlider" parent="SolverOptions"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+max_value = 200.0
+value = 1.0
+
+[node name="RestartButton" type="Button" parent="."]
+offset_left = 991.0
+offset_top = 495.0
+offset_right = 1104.0
+offset_bottom = 545.0
+theme_override_font_sizes/font_size = 30
+text = "Restart
+"
+
+[connection signal="drag_ended" from="SliderOptions/PointSlider" to="." method="_on_point_slider_drag_ended"]
+[connection signal="drag_ended" from="SliderOptions/CouplingSlider" to="." method="_on_coupling_slider_drag_ended"]
+[connection signal="drag_ended" from="SliderOptions/MeanSlider" to="." method="_on_mean_slider_drag_ended"]
+[connection signal="drag_ended" from="SliderOptions/StdSlider" to="." method="_on_std_slider_drag_ended"]
+[connection signal="item_selected" from="Options/SolverOption" to="." method="_on_solver_option_item_selected"]
+[connection signal="item_selected" from="Options/IntegratorOption" to="." method="_on_integrator_option_item_selected"]
+[connection signal="drag_ended" from="SolverOptions/SubstepSlider" to="." method="_on_substep_slider_drag_ended"]
+[connection signal="pressed" from="RestartButton" to="." method="_on_restart_button_pressed"]

--- a/demo/demos/kuramoto_model/kuramoto_model.tscn
+++ b/demo/demos/kuramoto_model/kuramoto_model.tscn
@@ -8,7 +8,8 @@
 script = ExtResource("1_4fesd")
 N = 100
 coupling = 3.0
-solver = NodePath("Solvers/NDSolver")
+solver = NodePath("Solvers/GDSolver")
+entity_color = Color(1, 1, 0.227451, 1)
 
 [node name="Solvers" type="Node" parent="."]
 
@@ -82,7 +83,6 @@ text = "Coupling: 1.0"
 [node name="CouplingSlider" type="HSlider" parent="SliderOptions"]
 unique_name_in_owner = true
 layout_mode = 2
-min_value = 1.0
 max_value = 10.0
 step = 0.05
 value = 1.0
@@ -123,12 +123,10 @@ metadata/_edit_group_ = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 30
 selected = 0
-item_count = 3
+item_count = 2
 popup/item_0/text = "GDScript"
 popup/item_1/text = "NumDot"
 popup/item_1/id = 1
-popup/item_2/text = "NumDot In-place"
-popup/item_2/id = 2
 
 [node name="IntegratorOption" type="OptionButton" parent="Options"]
 layout_mode = 2

--- a/demo/demos/kuramoto_model/kuramoto_model.tscn
+++ b/demo/demos/kuramoto_model/kuramoto_model.tscn
@@ -9,7 +9,6 @@ script = ExtResource("1_4fesd")
 N = 100
 coupling = 3.0
 solver = NodePath("Solvers/GDSolver")
-entity_color = Color(1, 1, 0.227451, 1)
 
 [node name="Solvers" type="Node" parent="."]
 
@@ -70,7 +69,7 @@ text = "Fireflies: 100
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 10.0
-max_value = 10000.0
+max_value = 20000.0
 step = 100.0
 value = 110.0
 
@@ -166,6 +165,8 @@ offset_bottom = 545.0
 theme_override_font_sizes/font_size = 30
 text = "Restart
 "
+
+[node name="Fireflies" type="Node2D" parent="."]
 
 [connection signal="drag_ended" from="SliderOptions/PointSlider" to="." method="_on_point_slider_drag_ended"]
 [connection signal="drag_ended" from="SliderOptions/CouplingSlider" to="." method="_on_coupling_slider_drag_ended"]

--- a/demo/demos/kuramoto_model/nd_solver.gd
+++ b/demo/demos/kuramoto_model/nd_solver.gd
@@ -23,8 +23,8 @@ func initialize() -> void:
 	phase = nd.multiply(2*PI, rng.random(params.N))
 	omega = nd.add(nd.multiply(rng.randn(params.N), params.frequency_sigma), params.frequency_mean)
 	
-	phase_coherence = nd.zeros(params.N)
-	avg_phase = nd.zeros(params.N)
+	phase_coherence = nd.zeros(1)
+	avg_phase = nd.zeros(1)
 	phase_sin = nd.zeros(params.N)
 	phase_cos = nd.zeros(params.N)
 	

--- a/demo/demos/kuramoto_model/nd_solver.gd
+++ b/demo/demos/kuramoto_model/nd_solver.gd
@@ -58,8 +58,10 @@ func rk4_step(dt: float) -> void:
 	phase.assign_add(phase, nd.multiply(dt/6, nd.add(k1, nd.add(nd.multiply(2, k2), nd.add(nd.multiply(2, k3), k4)))))
 
 func on_draw() -> void:
-	for i in params.N:
-		params.draw_circle(params.positions[i], params.entity_size, Color(params.entity_color, sin(phase.get_float(i))/2 + 0.5))
-
+	phase_sin.assign_divide(phase, 2)
+	phase_sin.assign_add(phase_sin, 0.5)
+	phase_sin.assign_sin(phase_sin)
+	params.set_alphas(phase_sin)
+	
 func generate_frequencies() -> void:
 	omega = nd.add(nd.multiply(rng.randn(params.N), params.frequency_sigma), params.frequency_mean)

--- a/demo/demos/kuramoto_model/nd_solver.gd
+++ b/demo/demos/kuramoto_model/nd_solver.gd
@@ -1,0 +1,65 @@
+extends KuramotoSolver
+
+var omega: NDArray # natural frequencies
+var phase: NDArray # oscillator phases
+
+# pre-allocations
+var rng := nd.default_rng()
+
+var phase_coherence: NDArray
+var avg_phase: NDArray
+var phase_sin: NDArray
+var phase_cos: NDArray
+
+# rk4
+var k1: NDArray
+var k2: NDArray
+var k3: NDArray
+var k4: NDArray
+
+func initialize() -> void:
+	integrator = [Callable(euler_step), Callable(rk4_step)]
+
+	phase = nd.multiply(2*PI, rng.random(params.N))
+	omega = nd.add(nd.multiply(rng.randn(params.N), params.frequency_sigma), params.frequency_mean)
+	
+	phase_coherence = nd.zeros(params.N)
+	avg_phase = nd.zeros(params.N)
+	phase_sin = nd.zeros(params.N)
+	phase_cos = nd.zeros(params.N)
+	
+	k1 = nd.zeros(params.N)
+	k2 = nd.zeros(params.N)
+	k3 = nd.zeros(params.N)
+	k4 = nd.zeros(params.N)
+
+func simulation_step() -> void:
+	var dt_substep: float = params.dt / params.sub_steps
+	for i in params.sub_steps: integrator[params.integrator_idx].call(dt_substep)
+
+func compute_derivative(df: NDArray, phase: NDArray):
+	phase_sin.assign_sin(phase)
+	phase_cos.assign_cos(phase)
+	phase_coherence.assign_divide(nd.sqrt(nd.add(nd.square(nd.sum(phase_cos)), nd.square(nd.sum(phase_sin)))), phase.size())
+	avg_phase.assign_atan2(nd.sum(phase_sin), nd.sum(phase_cos))
+	
+	df.assign_subtract(omega, nd.multiply(nd.multiply(params.coupling, phase_coherence), nd.sin(nd.subtract(phase, avg_phase))))
+
+func euler_step(dt: float) -> void:
+	compute_derivative(k1, phase)
+	phase.assign_add(phase, nd.multiply(k1, dt))
+
+func rk4_step(dt: float) -> void:
+	compute_derivative(k1, phase)
+	compute_derivative(k2, nd.add(phase, nd.multiply(k1, dt/2)))
+	compute_derivative(k3, nd.add(phase, nd.multiply(k2, dt/2)))
+	compute_derivative(k4, nd.add(phase, nd.multiply(k3, dt)))
+	
+	phase.assign_add(phase, nd.multiply(dt/6, nd.add(k1, nd.add(nd.multiply(2, k2), nd.add(nd.multiply(2, k3), k4)))))
+
+func on_draw() -> void:
+	for i in params.N:
+		params.draw_circle(params.positions[i], params.entity_size, Color(params.entity_color, sin(phase.get_float(i))/2 + 0.5))
+
+func generate_frequencies() -> void:
+	omega = nd.add(nd.multiply(rng.randn(params.N), params.frequency_sigma), params.frequency_mean)

--- a/demo/demos/kuramoto_model/solver.gd
+++ b/demo/demos/kuramoto_model/solver.gd
@@ -1,0 +1,20 @@
+extends Node
+class_name KuramotoSolver
+
+@export var params: Node2D
+var integrator: Array[Callable]
+
+func initialize() -> void:
+	pass
+
+func simulation_step() -> void:
+	pass
+	
+func on_draw() -> void:
+	pass
+
+func generate_frequencies() -> void:
+	pass
+	
+func set_integrator(idx: int) -> void:
+	pass

--- a/doc_classes/NDRandomGenerator.xml
+++ b/doc_classes/NDRandomGenerator.xml
@@ -18,7 +18,15 @@
 			<param index="3" name="dtype" type="int" enum="nd.DType" default="6" />
 			<param index="4" name="endpoint" type="bool" default="false" />
 			<description>
-				Return random integers from the “discrete uniform” distribution of the specified dtype. If high is None (the default), then results are from 0 to low.
+				Return random integers sampled from the “discrete uniform” distribution of the specified dtype. If high is None (the default), then results are from 0 to low.
+			</description>
+		</method>
+		<method name="randn">
+			<return type="NDArray" />
+			<param index="0" name="shape" type="Variant" default="PackedByteArray()" />
+			<param index="1" name="dtype" type="int" enum="nd.DType" default="2" />
+			<description>
+				Return random integers sampled from the standard normal distribution `N(0, 1)` of the specified dtype. A general gaussian distribution `N(mu, sig)` may be obtained by multiplying the result with `sig` and adding it with `mu`.
 			</description>
 		</method>
 		<method name="random">

--- a/src/ndrandomgenerator.cpp
+++ b/src/ndrandomgenerator.cpp
@@ -35,6 +35,7 @@ void NDRandomGenerator::_bind_methods() {
 
 	godot::ClassDB::bind_method(D_METHOD("random", "shape", "dtype"), &NDRandomGenerator::random, DEFVAL(PackedByteArray()), DEFVAL(va::DType::Float64));
 	godot::ClassDB::bind_method(D_METHOD("integers", "low_or_high", "high", "shape", "dtype", "endpoint"), &NDRandomGenerator::integers, DEFVAL(0), DEFVAL(nullptr), DEFVAL(PackedByteArray()), DEFVAL(va::DType::Int64), DEFVAL(false));
+	godot::ClassDB::bind_method(D_METHOD("randn", "shape", "dtype"), &NDRandomGenerator::randn, DEFVAL(PackedByteArray()), DEFVAL(va::DType::Float64));
 }
 
 NDRandomGenerator::NDRandomGenerator() = default;
@@ -78,6 +79,17 @@ Ref<NDArray> NDRandomGenerator::integers(const int64_t low_or_high, const Varian
 				ERR_FAIL_V_MSG({}, "high is not an int");
 		}
 
+	}
+	catch (std::runtime_error& error) {
+		ERR_FAIL_V_MSG({}, error.what());
+	}
+}
+
+Ref<NDArray> NDRandomGenerator::randn(const Variant& shape, const va::DType dtype) {
+	try {
+		const auto shape_array = variant_to_shape(shape);
+
+		return { memnew(NDArray(engine.random_normal(shape_array, dtype))) };
 	}
 	catch (std::runtime_error& error) {
 		ERR_FAIL_V_MSG({}, error.what());

--- a/src/ndrandomgenerator.hpp
+++ b/src/ndrandomgenerator.hpp
@@ -66,6 +66,7 @@ public:
 
 	Ref<NDArray> random(const Variant& shape = PackedByteArray(), va::DType dtype = va::Float64);
 	Ref<NDArray> integers(int64_t low_or_high, const Variant& high, const Variant& shape = PackedByteArray(), va::DType dtype = va::Float64, bool endpoint = false);
+	Ref<NDArray> randn(const Variant& shape = PackedByteArray(), va::DType dtype = va::Float64);
 };
 
 #endif

--- a/src/vatensor/vrandom.cpp
+++ b/src/vatensor/vrandom.cpp
@@ -67,3 +67,22 @@ std::shared_ptr<VArray> VRandomEngine::random_integers(long long low, long long 
 	);
 #endif
 }
+
+std::shared_ptr<va::VArray> VRandomEngine::random_normal(shape_type shape, const DType dtype) {
+#ifdef NUMDOT_DISABLE_RANDOM_FUNCTIONS
+	throw std::runtime_error("function explicitly disabled; recompile without NUMDOT_DISABLE_RANDOM_FUNCTIONS to enable it.");
+#else
+	return std::visit(
+		[shape, this](auto t) -> std::shared_ptr<va::VArray> {
+			using T = decltype(t);
+
+			if constexpr (!std::is_floating_point_v<T>) {
+				throw std::runtime_error("This function can only generate floating point types.");
+			}
+			else {
+				return from_store(make_store<T>(xt::random::randn<T>(shape, 0, 1, this->engine)));
+			}
+		}, dtype_to_variant(dtype)
+	);
+#endif
+}

--- a/src/vatensor/vrandom.hpp
+++ b/src/vatensor/vrandom.hpp
@@ -19,6 +19,7 @@ namespace va::random {
 
 		std::shared_ptr<VArray> random_floats(shape_type shape, DType dtype);
 		std::shared_ptr<VArray> random_integers(long long low, long long high, shape_type shape, DType dtype, bool endpoint);
+		std::shared_ptr<VArray> random_normal(shape_type shape, DType dtype);
 	};
 }
 


### PR DESCRIPTION
Adds a demo of [Kuramoto model](https://en.wikipedia.org/wiki/Kuramoto_model) which describes synchronization of oscillators (fire-flies in this case!). Includes fine controls to swap integration schemes between [Euler method](https://en.wikipedia.org/wiki/Euler_method) and [RK4](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods) and set the number of sub-steps.

Also adds `randn` function to sample the standard normal distribution which was required for this simulation.